### PR TITLE
Fixed chat for higher res videos

### DIFF
--- a/modes/masked.sh
+++ b/modes/masked.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
+VOD_HEIGHT="$("$(get_ffmpeg_path)/ffprobe" -v quiet -of default=nk=1:nw=1 -select_streams v:0 -show_entries stream=height "${VOD_ID}/vod.mp4")"
 $(twitch_dl "chatrender") -i "${VOD_ID}/chat.json" -o "${VOD_ID}/chat.mp4" \
-    -w $([[ -n $CHAT_WIDTH ]] && echo -n "${CHAT_WIDTH}" || echo -n "340") -h 1080 \
+    -w $([[ -n $CHAT_WIDTH ]] && echo -n "${CHAT_WIDTH}" || echo -n "340") -h "$VOD_HEIGHT" \
     $([[ -n $EMOJI_VENDOR ]] && echo -n "--emoji-vendor "${EMOJI_VENDOR}"") \
     --update-rate 0 --dispersion true \
-    $([[ -n $EMOJI_VENDOR ]] && echo -n "--emoji-vendor "${EMOJI_VENDOR}"") \
     $([[ -n $CHAT_FONT ]] && echo -n "--font "${CHAT_FONT}"") \
     $([[ -n $CHAT_FONT_SIZE ]] && echo -n "--font-size ${CHAT_FONT_SIZE}") \
     --outline true --generate-mask --background-color '#00000000' \


### PR DESCRIPTION
If a video has a higher res than 1920x1080, the chat would be cut off since the rendering is hard-coded to a height of 1080 pixels. This PR gets the VOD's res using `ffprobe` and uses that instead.
The `--emoji-vendor` option was also specified twice, so I removed one.